### PR TITLE
Add fullscreen modal size and overlay customization support

### DIFF
--- a/src/Modal/Modal.stories.tsx
+++ b/src/Modal/Modal.stories.tsx
@@ -17,7 +17,7 @@ const meta: Meta<typeof Modal> = {
   argTypes: {
     size: {
       control: 'select',
-      options: ['sm', 'md', 'lg', 'xl', 'full'],
+      options: ['sm', 'md', 'lg', 'xl', 'full', 'fullscreen'],
     },
     closeOnOverlay: {
       control: 'boolean',
@@ -31,7 +31,7 @@ const meta: Meta<typeof Modal> = {
 export default meta;
 type Story = StoryObj<typeof Modal>;
 
-const ModalDemo = ({ size = 'md' }: { size?: 'sm' | 'md' | 'lg' | 'xl' | 'full' }) => {
+const ModalDemo = ({ size = 'md', overlayClassName }: { size?: 'sm' | 'md' | 'lg' | 'xl' | 'full' | 'fullscreen'; overlayClassName?: string }) => {
   const [open, setOpen] = useState(false);
 
   return (
@@ -51,7 +51,7 @@ const ModalDemo = ({ size = 'md' }: { size?: 'sm' | 'md' | 'lg' | 'xl' | 'full' 
         Open Modal
       </button>
 
-      <Modal open={open} onClose={() => setOpen(false)} size={size}>
+      <Modal open={open} onClose={() => setOpen(false)} size={size} overlayClassName={overlayClassName}>
         <ModalHeader
           title="Modal Title"
           subtitle="Optional subtitle text"
@@ -107,6 +107,138 @@ export const Small: Story = {
 
 export const Large: Story = {
   render: () => <ModalDemo size="lg" />,
+};
+
+export const Fullscreen: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+
+    return (
+      <>
+        <button
+          onClick={() => setOpen(true)}
+          style={{
+            padding: '10px 20px',
+            background: '#E85A4F',
+            color: 'white',
+            border: 'none',
+            borderRadius: '8px',
+            cursor: 'pointer',
+            fontWeight: 500,
+          }}
+        >
+          Open Fullscreen Modal
+        </button>
+
+        <Modal open={open} onClose={() => setOpen(false)} size="fullscreen">
+          <ModalHeader
+            title="Document Viewer"
+            subtitle="Fullscreen modal for immersive content"
+            onClose={() => setOpen(false)}
+          />
+          <ModalBody>
+            <div style={{ display: 'flex', flexDirection: 'column', height: '100%', gap: '16px' }}>
+              <p style={{ margin: 0, color: '#666' }}>
+                This fullscreen modal fills the entire viewport — ideal for PDF viewers,
+                document editors, or other immersive content.
+              </p>
+              <div
+                style={{
+                  flex: 1,
+                  background: '#f0f0f0',
+                  borderRadius: '8px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  color: '#999',
+                  fontSize: '18px',
+                  minHeight: '200px',
+                }}
+              >
+                PDF / Document content area
+              </div>
+            </div>
+          </ModalBody>
+          <ModalFooter>
+            <button
+              onClick={() => setOpen(false)}
+              style={{
+                padding: '8px 16px',
+                background: 'transparent',
+                color: '#1A1A1A',
+                border: '1px solid #E5E5E5',
+                borderRadius: '8px',
+                cursor: 'pointer',
+              }}
+            >
+              Close
+            </button>
+          </ModalFooter>
+        </Modal>
+      </>
+    );
+  },
+};
+
+export const WithOverlayClassName: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+
+    return (
+      <>
+        <style>{`.custom-overlay { background: rgba(229, 90, 79, 0.15) !important; }`}</style>
+        <button
+          onClick={() => setOpen(true)}
+          style={{
+            padding: '10px 20px',
+            background: '#E85A4F',
+            color: 'white',
+            border: 'none',
+            borderRadius: '8px',
+            cursor: 'pointer',
+            fontWeight: 500,
+          }}
+        >
+          Open Modal with Custom Overlay
+        </button>
+
+        <Modal
+          open={open}
+          onClose={() => setOpen(false)}
+          size="md"
+          overlayClassName="custom-overlay"
+        >
+          <ModalHeader
+            title="Custom Overlay"
+            subtitle="The overlay behind this modal uses a custom class"
+            onClose={() => setOpen(false)}
+          />
+          <ModalBody>
+            <p style={{ margin: 0 }}>
+              The <code>overlayClassName</code> prop lets you style the overlay container.
+              This example uses a coral-tinted overlay instead of the default dark backdrop.
+            </p>
+          </ModalBody>
+          <ModalFooter>
+            <button
+              onClick={() => setOpen(false)}
+              style={{
+                padding: '8px 16px',
+                background: '#E85A4F',
+                color: 'white',
+                border: 'none',
+                borderRadius: '8px',
+                cursor: 'pointer',
+                fontWeight: 500,
+              }}
+            >
+              Got it
+            </button>
+          </ModalFooter>
+        </Modal>
+      </>
+    );
+  },
 };
 
 export const Confirmation: Story = {

--- a/src/Modal/Modal.styles.ts
+++ b/src/Modal/Modal.styles.ts
@@ -32,6 +32,12 @@ export const modalStyles = `
 .oc-modal--lg { width: 100%; max-width: 640px; }
 .oc-modal--xl { width: 100%; max-width: 800px; }
 .oc-modal--full { width: 100%; max-width: calc(100vw - 32px); height: calc(100vh - 32px); }
+.oc-modal--fullscreen { width: 100vw; max-width: 100vw; height: 100vh; border-radius: 0; }
+
+/* Fullscreen overlay removes padding */
+.oc-modal-overlay:has(.oc-modal--fullscreen) {
+  padding: 0;
+}
 
 /* Modal Header */
 .oc-modal-header {

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, ReactNode, HTMLAttributes, useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 
-export type ModalSize = 'sm' | 'md' | 'lg' | 'xl' | 'full';
+export type ModalSize = 'sm' | 'md' | 'lg' | 'xl' | 'full' | 'fullscreen';
 
 export interface ModalProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
   open: boolean;
@@ -9,6 +9,7 @@ export interface ModalProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'
   size?: ModalSize;
   closeOnOverlay?: boolean;
   closeOnEscape?: boolean;
+  overlayClassName?: string;
   children?: ReactNode;
 }
 
@@ -32,6 +33,7 @@ export const Modal = forwardRef<HTMLDivElement, ModalProps>(
       size = 'md',
       closeOnOverlay = true,
       closeOnEscape = true,
+      overlayClassName = '',
       className = '',
       children,
       ...props
@@ -72,8 +74,13 @@ export const Modal = forwardRef<HTMLDivElement, ModalProps>(
       className,
     ].filter(Boolean).join(' ');
 
+    const overlayClasses = [
+      'oc-modal-overlay',
+      overlayClassName,
+    ].filter(Boolean).join(' ');
+
     const content = (
-      <div className="oc-modal-overlay" onClick={handleOverlayClick}>
+      <div className={overlayClasses} onClick={handleOverlayClick}>
         <div ref={ref} className={modalClasses} role="dialog" aria-modal="true" {...props}>
           {children}
         </div>


### PR DESCRIPTION
## Summary
This PR extends the Modal component with two new features: a `fullscreen` size option that fills the entire viewport, and an `overlayClassName` prop that allows customization of the overlay backdrop styling.

## Key Changes
- **New Modal Size**: Added `fullscreen` as a new `ModalSize` option that expands the modal to fill 100% of the viewport with no border radius
- **Overlay Customization**: Introduced `overlayClassName` prop to allow custom CSS classes on the overlay container, enabling flexible styling of the backdrop
- **Fullscreen Styling**: Added CSS rule to remove padding from the overlay when a fullscreen modal is active, ensuring true full-viewport coverage
- **Story Examples**: Added two new Storybook stories demonstrating the fullscreen modal and custom overlay styling capabilities
- **Type Updates**: Updated `ModalSize` type and `ModalDemo` component signature to include the new `fullscreen` option and `overlayClassName` parameter

## Implementation Details
- The `overlayClassName` prop is optional and defaults to an empty string, maintaining backward compatibility
- Fullscreen modals use `100vw` and `100vh` dimensions with `border-radius: 0` for a seamless full-screen experience
- The overlay padding is conditionally removed for fullscreen modals using the `:has()` CSS selector
- Both new features are fully integrated into the component's TypeScript types and Storybook controls

https://claude.ai/code/session_01PSAxYns61USrMW9FmzmuJD