### PR TITLE
Add onBlur callback to Dropdown component

### DIFF
--- a/src/Dropdown/Dropdown.stories.tsx
+++ b/src/Dropdown/Dropdown.stories.tsx
@@ -624,3 +624,36 @@ export const AllModes: Story = {
     ),
   ],
 };
+
+// ─── onBlur callback ──────────────────────────────────────────────────────
+
+export const OnBlurCallback: Story = {
+  render: () => {
+    const [blurCount, setBlurCount] = useState(0);
+    const [lastEvent, setLastEvent] = useState('');
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <div style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#94a3b8' }}>
+          onBlur — focus the dropdown, then tab or click away
+        </div>
+        <Dropdown
+          mode="select"
+          options={embeddingModels}
+          placeholder="Select model"
+          aria-label="onBlur demo"
+          onBlur={() => {
+            setBlurCount(c => c + 1);
+            setLastEvent(new Date().toLocaleTimeString());
+          }}
+          searchable="local"
+        />
+        <input placeholder="Tab target (focus me)" style={{ padding: '8px 12px', border: '1px solid #e2e8f0', borderRadius: 6 }} />
+        <div style={{ fontSize: 13, color: '#64748b' }}>
+          Blur count: <strong>{blurCount}</strong>
+          {lastEvent && <> — last at {lastEvent}</>}
+        </div>
+      </div>
+    );
+  },
+};

--- a/src/Dropdown/Dropdown.test.tsx
+++ b/src/Dropdown/Dropdown.test.tsx
@@ -773,6 +773,123 @@ describe('Dropdown — Ref forwarding', () => {
   });
 });
 
+// ─── onBlur ──────────────────────────────────────────────────────────────
+
+describe('Dropdown — onBlur', () => {
+  it('fires onBlur when focus leaves the dropdown', () => {
+    const handleBlur = vi.fn();
+    const { container } = render(
+      <div>
+        <Dropdown
+          mode="select"
+          options={basicOptions}
+          aria-label="Blur test"
+          onBlur={handleBlur}
+        />
+        <button data-testid="outside">Outside</button>
+      </div>
+    );
+
+    const trigger = screen.getByRole('combobox');
+    trigger.focus();
+
+    // Move focus to outside button
+    fireEvent.blur(trigger, {
+      relatedTarget: screen.getByTestId('outside'),
+    });
+
+    expect(handleBlur).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire onBlur for internal focus transfers (trigger → menu)', () => {
+    const handleBlur = vi.fn();
+    const { container } = render(
+      <Dropdown
+        mode="select"
+        options={basicOptions}
+        aria-label="Internal blur test"
+        onBlur={handleBlur}
+        searchable="local"
+      />
+    );
+
+    const trigger = screen.getByRole('combobox');
+    trigger.focus();
+    fireEvent.click(trigger);
+
+    // Search input should now be focused — this is an internal transfer
+    const searchInput = screen.getByRole('searchbox');
+    fireEvent.blur(trigger, { relatedTarget: searchInput });
+
+    expect(handleBlur).not.toHaveBeenCalled();
+  });
+
+  it('fires onBlur when tabbing away without opening menu', () => {
+    const handleBlur = vi.fn();
+    render(
+      <div>
+        <Dropdown
+          mode="select"
+          options={basicOptions}
+          aria-label="Tab blur test"
+          onBlur={handleBlur}
+        />
+        <button data-testid="next">Next</button>
+      </div>
+    );
+
+    const trigger = screen.getByRole('combobox');
+    trigger.focus();
+
+    // Tab away — fires blur with relatedTarget outside the dropdown
+    fireEvent.blur(trigger, {
+      relatedTarget: screen.getByTestId('next'),
+    });
+
+    expect(handleBlur).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onBlur in menu mode when focus leaves', () => {
+    const handleBlur = vi.fn();
+    render(
+      <div>
+        <Dropdown mode="menu" aria-label="Menu blur test" onBlur={handleBlur}>
+          <Dropdown.Item onClick={() => {}}>Action</Dropdown.Item>
+        </Dropdown>
+        <button data-testid="other">Other</button>
+      </div>
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Menu blur test' });
+    trigger.focus();
+
+    fireEvent.blur(trigger, {
+      relatedTarget: screen.getByTestId('other'),
+    });
+
+    expect(handleBlur).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire when onBlur prop is not provided', () => {
+    // Just ensure no errors when onBlur is omitted
+    render(
+      <div>
+        <Dropdown
+          mode="select"
+          options={basicOptions}
+          aria-label="No blur handler"
+        />
+        <button data-testid="out">Out</button>
+      </div>
+    );
+
+    const trigger = screen.getByRole('combobox');
+    trigger.focus();
+    fireEvent.blur(trigger, { relatedTarget: screen.getByTestId('out') });
+    // No error thrown
+  });
+});
+
 // ─── displayName ─────────────────────────────────────────────────────────
 
 describe('Dropdown — displayName', () => {

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -130,6 +130,12 @@ export interface DropdownProps<T extends string | number = string> {
   /** Called when the dropdown closes. */
   onClose?: () => void;
 
+  /** Called when focus leaves the dropdown's DOM tree (trigger + menu).
+   *  Fires for tab-away, click-outside, and programmatic focus changes —
+   *  even when the menu was never opened. Internal focus transfers between
+   *  trigger and menu are suppressed. */
+  onBlur?: (event: React.FocusEvent) => void;
+
   /** Children — used for compound component pattern (Dropdown.Item, etc.) */
   children?: ReactNode;
 }
@@ -326,6 +332,7 @@ function DropdownInner<T extends string | number = string>(
     'aria-labelledby': ariaLabelledBy,
     onOpen,
     onClose,
+    onBlur,
     children,
   }: DropdownProps<T>,
   ref: React.ForwardedRef<HTMLDivElement>
@@ -1058,6 +1065,24 @@ function DropdownInner<T extends string | number = string>(
     }
   }, [isOpen, mode]);
 
+  // Handle focus leaving the entire dropdown tree
+  const handleFocusOut = useCallback(
+    (e: React.FocusEvent) => {
+      if (!onBlur) return;
+      // relatedTarget is the element receiving focus. If it's inside this
+      // container we are just moving between trigger ↔ menu — suppress.
+      if (
+        containerRef.current &&
+        e.relatedTarget instanceof Node &&
+        containerRef.current.contains(e.relatedTarget)
+      ) {
+        return;
+      }
+      onBlur(e);
+    },
+    [onBlur]
+  );
+
   const rootClasses = [
     'oc-dropdown',
     `oc-dropdown--${mode}`,
@@ -1080,6 +1105,7 @@ function DropdownInner<T extends string | number = string>(
       className={rootClasses}
       style={style}
       onKeyDown={mode === 'menu' ? handleMenuKeyDown : handleKeyDown}
+      onBlur={handleFocusOut}
     >
       {renderTriggerElement()}
       {renderMenu()}


### PR DESCRIPTION
## Summary
Adds an `onBlur` callback prop to the Dropdown component that fires when focus leaves the dropdown's DOM tree (trigger + menu), while intelligently suppressing internal focus transfers between the trigger and menu.

## Key Changes
- **New `onBlur` prop**: Added to `DropdownProps` interface with documentation explaining behavior
- **Focus tracking logic**: Implemented `handleFocusOut` callback that:
  - Only fires when focus moves outside the dropdown container
  - Suppresses blur events for internal focus transfers (trigger ↔ menu)
  - Passes the native `React.FocusEvent` to the callback
- **Container-level handler**: Attached `onBlur` handler to the root dropdown container to capture all focus-out events
- **Test coverage**: Added comprehensive test suite covering:
  - Focus leaving the dropdown entirely
  - Internal focus transfers (not triggering blur)
  - Tab-away behavior
  - Menu mode behavior
  - Missing onBlur prop (no errors)
- **Storybook example**: Added `OnBlurCallback` story demonstrating the feature with blur count tracking

## Implementation Details
The solution uses `containerRef.current.contains(e.relatedTarget)` to determine if focus is moving within the dropdown tree. This approach handles all focus scenarios (tab, click, programmatic) without requiring manual tracking of menu open/close state.

https://claude.ai/code/session_01LEXVmTRnnqcZSFzw7EyKzK