### PR TITLE
feat(Dropdown): add configurable iconSize for option icons

### DIFF
--- a/src/Dropdown/Dropdown.stories.tsx
+++ b/src/Dropdown/Dropdown.stories.tsx
@@ -657,3 +657,34 @@ export const OnBlurCallback: Story = {
     );
   },
 };
+
+// ─── Icon Size ────────────────────────────────────────────────────────────
+
+const labelSetOptions = [
+  { value: 'contract', label: 'Contract', icon: 'https://api.dicebear.com/7.x/shapes/svg?seed=contract', iconSize: 24 },
+  { value: 'nda', label: 'NDA', icon: 'https://api.dicebear.com/7.x/shapes/svg?seed=nda', iconSize: 24 },
+  { value: 'amendment', label: 'Amendment', icon: 'https://api.dicebear.com/7.x/shapes/svg?seed=amendment' },
+];
+
+export const IconSize: Story = {
+  name: 'Icon Size',
+  render: () => {
+    const [val, setVal] = useState<string | null>(null);
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <div style={{ fontSize: 13, color: '#64748b' }}>
+          Component-level <code>iconSize=20</code> with per-option override to 24
+        </div>
+        <Dropdown
+          mode="select"
+          options={labelSetOptions}
+          value={val}
+          onChange={(v) => setVal(v)}
+          placeholder="Select label"
+          iconSize={20}
+          aria-label="Icon size demo"
+        />
+      </div>
+    );
+  },
+};

--- a/src/Dropdown/Dropdown.styles.ts
+++ b/src/Dropdown/Dropdown.styles.ts
@@ -95,8 +95,15 @@ export const dropdownStyles = `
 }
 
 .oc-dropdown__trigger-icon svg {
-  width: 16px;
-  height: 16px;
+  width: var(--oc-dropdown-icon-size, 16px);
+  height: var(--oc-dropdown-icon-size, 16px);
+}
+
+.oc-dropdown__trigger-icon .oc-dropdown__option-icon-img {
+  width: var(--oc-dropdown-icon-size, 16px);
+  height: var(--oc-dropdown-icon-size, 16px);
+  object-fit: contain;
+  border-radius: 2px;
 }
 
 .oc-dropdown__value {
@@ -394,13 +401,13 @@ export const dropdownStyles = `
 }
 
 .oc-dropdown__option-icon svg {
-  width: 16px;
-  height: 16px;
+  width: var(--oc-dropdown-icon-size, 16px);
+  height: var(--oc-dropdown-icon-size, 16px);
 }
 
 .oc-dropdown__option-icon-img {
-  width: 16px;
-  height: 16px;
+  width: var(--oc-dropdown-icon-size, 16px);
+  height: var(--oc-dropdown-icon-size, 16px);
   object-fit: contain;
   border-radius: 2px;
 }
@@ -481,8 +488,8 @@ export const dropdownStyles = `
 }
 
 .oc-dropdown__item-icon svg {
-  width: 16px;
-  height: 16px;
+  width: var(--oc-dropdown-icon-size, 16px);
+  height: var(--oc-dropdown-icon-size, 16px);
 }
 
 .oc-dropdown__item-label {

--- a/src/Dropdown/Dropdown.test.tsx
+++ b/src/Dropdown/Dropdown.test.tsx
@@ -903,3 +903,62 @@ describe('Dropdown — displayName', () => {
     expect(Dropdown.Header.displayName).toBe('Dropdown.Header');
   });
 });
+
+// ─── iconSize ─────────────────────────────────────────────────────────────
+
+describe('Dropdown — iconSize', () => {
+  it('applies component-level iconSize to image icons', () => {
+    const opts: DropdownOption[] = [
+      { value: 'a', label: 'A', icon: 'https://example.com/logo.png' },
+    ];
+    const { container } = render(
+      <Dropdown mode="select" options={opts} iconSize={24} />
+    );
+    fireEvent.click(screen.getByRole('combobox'));
+
+    const img = container.querySelector('.oc-dropdown__option-icon-img') as HTMLImageElement;
+    expect(img).toBeDefined();
+    expect(img.style.getPropertyValue('--oc-dropdown-icon-size')).toBe('24px');
+  });
+
+  it('applies per-option iconSize overriding component-level', () => {
+    const opts: DropdownOption[] = [
+      { value: 'a', label: 'A', icon: 'https://example.com/a.png', iconSize: 32 },
+      { value: 'b', label: 'B', icon: 'https://example.com/b.png' },
+    ];
+    const { container } = render(
+      <Dropdown mode="select" options={opts} iconSize={20} />
+    );
+    fireEvent.click(screen.getByRole('combobox'));
+
+    const imgs = container.querySelectorAll('.oc-dropdown__option-icon-img') as NodeListOf<HTMLImageElement>;
+    expect(imgs[0].style.getPropertyValue('--oc-dropdown-icon-size')).toBe('32px');
+    expect(imgs[1].style.getPropertyValue('--oc-dropdown-icon-size')).toBe('20px');
+  });
+
+  it('does not set custom property when no iconSize is specified', () => {
+    const opts: DropdownOption[] = [
+      { value: 'a', label: 'A', icon: 'https://example.com/logo.png' },
+    ];
+    const { container } = render(
+      <Dropdown mode="select" options={opts} />
+    );
+    fireEvent.click(screen.getByRole('combobox'));
+
+    const img = container.querySelector('.oc-dropdown__option-icon-img') as HTMLImageElement;
+    expect(img.style.getPropertyValue('--oc-dropdown-icon-size')).toBe('');
+  });
+
+  it('applies iconSize to trigger icon for selected option', () => {
+    const opts: DropdownOption[] = [
+      { value: 'a', label: 'A', icon: 'https://example.com/logo.png', iconSize: 24 },
+    ];
+    const { container } = render(
+      <Dropdown mode="select" options={opts} value="a" />
+    );
+
+    const triggerImg = container.querySelector('.oc-dropdown__trigger-icon .oc-dropdown__option-icon-img') as HTMLImageElement;
+    expect(triggerImg).toBeDefined();
+    expect(triggerImg.style.getPropertyValue('--oc-dropdown-icon-size')).toBe('24px');
+  });
+});

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -21,6 +21,9 @@ export interface DropdownOption<T extends string | number = string> {
   label: string;
   /** Optional icon — a ReactNode (e.g., a Lucide icon) or image URL string. */
   icon?: ReactNode | string;
+  /** Override icon size in px for this option. Falls back to the
+   *  component-level `iconSize` prop, then to 16. */
+  iconSize?: number;
   /** Optional secondary text shown below the label in the menu. */
   description?: string;
   /** Disables this individual option. */
@@ -81,6 +84,10 @@ export interface DropdownProps<T extends string | number = string> {
 
   /** Debounce interval in ms for onSearchChange. Defaults to 300. */
   searchDebounceMs?: number;
+
+  /** Default icon size in px for option icons. Individual options can
+   *  override via their own `iconSize`. Defaults to 16. */
+  iconSize?: number;
 
   /** Makes the dropdown fill its container width. */
   fluid?: boolean;
@@ -318,6 +325,7 @@ function DropdownInner<T extends string | number = string>(
     searchable = false,
     onSearchChange,
     searchDebounceMs = 300,
+    iconSize,
     fluid = false,
     upward = false,
     align = 'left',
@@ -732,9 +740,13 @@ function DropdownInner<T extends string | number = string>(
 
   // ─── Render helpers ───────────────────────────────────────────────────
 
-  const renderIcon = (icon: ReactNode | string) => {
+  const renderIcon = (icon: ReactNode | string, size?: number) => {
+    const sizeStyle = size ? { '--oc-dropdown-icon-size': `${size}px` } as React.CSSProperties : undefined;
     if (typeof icon === 'string') {
-      return <img src={icon} alt="" className="oc-dropdown__option-icon-img" />;
+      return <img src={icon} alt="" className="oc-dropdown__option-icon-img" style={sizeStyle} />;
+    }
+    if (size) {
+      return <span style={sizeStyle}>{icon}</span>;
     }
     return icon;
   };
@@ -780,7 +792,7 @@ function DropdownInner<T extends string | number = string>(
         <div className="oc-dropdown__trigger-content">
           {selectedOpt.icon && (
             <span className="oc-dropdown__trigger-icon">
-              {renderIcon(selectedOpt.icon)}
+              {renderIcon(selectedOpt.icon, selectedOpt.iconSize ?? iconSize)}
             </span>
           )}
           <span className="oc-dropdown__value">{selectedOpt.label}</span>
@@ -961,7 +973,7 @@ function DropdownInner<T extends string | number = string>(
         >
           {opt.icon && (
             <span className="oc-dropdown__option-icon">
-              {renderIcon(opt.icon)}
+              {renderIcon(opt.icon, opt.iconSize ?? iconSize)}
             </span>
           )}
           <div className="oc-dropdown__option-content">


### PR DESCRIPTION
Add iconSize prop at both component and per-option level to allow
customizing icon dimensions. Fixes the 16px hardcoded size being
too small for label set use cases with uploaded logos.

- DropdownOption.iconSize: per-option override
- DropdownProps.iconSize: component-level default
- CSS uses --oc-dropdown-icon-size custom property with 16px fallback

Closes #9

https://claude.ai/code/session_011QqERbc29C2DybmMTMW1n5