### PR TITLE
Add wrapDescriptions and showDescriptionInTrigger props to Dropdown

### DIFF
--- a/src/Dropdown/Dropdown.stories.tsx
+++ b/src/Dropdown/Dropdown.stories.tsx
@@ -559,6 +559,52 @@ export const CustomEmptyState: Story = {
   },
 };
 
+// ─── Description Features ───────────────────────────────────────────
+
+const embeddingModelsWithDescriptions = [
+  { value: 'openai-3-small', label: 'text-embedding-3-small', description: 'Standard text embedding model (384 dimensions)' },
+  { value: 'openai-3-large', label: 'text-embedding-3-large', description: 'Higher-quality embeddings with configurable dimensions (up to 3072)' },
+  { value: 'cohere-v3', label: 'Cohere Embed v3', description: 'Multilingual model with strong retrieval performance' },
+  { value: 'bge-large', label: 'BGE Large EN v1.5', description: 'Open-source English embedding model from BAAI (1024 dimensions)' },
+];
+
+export const WrappedDescriptions: Story = {
+  render: () => {
+    const [value, setValue] = useState<string | null>(null);
+    return (
+      <Dropdown
+        mode="select"
+        options={embeddingModelsWithDescriptions}
+        value={value}
+        onChange={(val) => setValue(val as string | null)}
+        placeholder="Select embedding model"
+        aria-label="Embedding model"
+        wrapDescriptions
+        fluid
+      />
+    );
+  },
+};
+
+export const DescriptionInTrigger: Story = {
+  render: () => {
+    const [value, setValue] = useState<string>('openai-3-small');
+    return (
+      <Dropdown
+        mode="select"
+        options={embeddingModelsWithDescriptions}
+        value={value}
+        onChange={(val) => setValue(val as string)}
+        placeholder="Select embedding model"
+        aria-label="Embedding model"
+        wrapDescriptions
+        showDescriptionInTrigger
+        fluid
+      />
+    );
+  },
+};
+
 // ─── All Modes Side-by-Side ──────────────────────────────────────────────
 
 export const AllModes: Story = {

--- a/src/Dropdown/Dropdown.styles.ts
+++ b/src/Dropdown/Dropdown.styles.ts
@@ -107,6 +107,22 @@ export const dropdownStyles = `
   color: var(--oc-fg-primary);
 }
 
+.oc-dropdown__trigger-value-group {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+}
+
+.oc-dropdown__trigger-description {
+  font-size: var(--oc-font-size-xs);
+  color: var(--oc-fg-secondary);
+  line-height: var(--oc-line-height-normal);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .oc-dropdown__placeholder {
   flex: 1;
   white-space: nowrap;
@@ -426,6 +442,12 @@ export const dropdownStyles = `
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.oc-dropdown--wrap-descriptions .oc-dropdown__option-description {
+  white-space: normal;
+  overflow: visible;
+  text-overflow: clip;
 }
 
 .oc-dropdown__option--selected .oc-dropdown__option-description {

--- a/src/Dropdown/Dropdown.test.tsx
+++ b/src/Dropdown/Dropdown.test.tsx
@@ -890,6 +890,85 @@ describe('Dropdown — onBlur', () => {
   });
 });
 
+// ─── Description features ─────────────────────────────────────────────
+
+describe('Dropdown — Description wrapping', () => {
+  const descOptions: DropdownOption[] = [
+    { value: 'a', label: 'Model A', description: 'Standard text embedding model (384 dimensions)' },
+    { value: 'b', label: 'Model B', description: 'Large model' },
+  ];
+
+  it('applies wrap-descriptions class when wrapDescriptions is true', () => {
+    const { container } = renderDropdown({ options: descOptions, wrapDescriptions: true });
+    expect(container.firstElementChild?.className).toContain('wrap-descriptions');
+  });
+
+  it('does not apply wrap-descriptions class by default', () => {
+    const { container } = renderDropdown({ options: descOptions });
+    expect(container.firstElementChild?.className).not.toContain('wrap-descriptions');
+  });
+
+  it('renders descriptions in menu options', () => {
+    renderDropdown({ options: descOptions, wrapDescriptions: true });
+    fireEvent.click(screen.getByRole('combobox'));
+
+    expect(screen.getByText('Standard text embedding model (384 dimensions)')).toBeDefined();
+    expect(screen.getByText('Large model')).toBeDefined();
+  });
+});
+
+describe('Dropdown — Show description in trigger', () => {
+  const descOptions: DropdownOption[] = [
+    { value: 'a', label: 'Model A', description: 'Standard embedding model' },
+    { value: 'b', label: 'Model B' },
+  ];
+
+  it('shows description in trigger when showDescriptionInTrigger is true and option has description', () => {
+    renderDropdown({
+      options: descOptions,
+      value: 'a',
+      showDescriptionInTrigger: true,
+    });
+
+    expect(screen.getByText('Model A')).toBeDefined();
+    expect(screen.getByText('Standard embedding model')).toBeDefined();
+  });
+
+  it('does not show description in trigger by default', () => {
+    renderDropdown({
+      options: descOptions,
+      value: 'a',
+    });
+
+    expect(screen.getByText('Model A')).toBeDefined();
+    expect(screen.queryByText('Standard embedding model')).toBeNull();
+  });
+
+  it('does not show description in trigger when selected option has no description', () => {
+    renderDropdown({
+      options: descOptions,
+      value: 'b',
+      showDescriptionInTrigger: true,
+    });
+
+    expect(screen.getByText('Model B')).toBeDefined();
+    // No description element should be rendered
+    const trigger = screen.getByRole('combobox');
+    expect(trigger.querySelector('.oc-dropdown__trigger-description')).toBeNull();
+  });
+
+  it('renders trigger-value-group class when showing description', () => {
+    renderDropdown({
+      options: descOptions,
+      value: 'a',
+      showDescriptionInTrigger: true,
+    });
+
+    const trigger = screen.getByRole('combobox');
+    expect(trigger.querySelector('.oc-dropdown__trigger-value-group')).not.toBeNull();
+  });
+});
+
 // ─── displayName ─────────────────────────────────────────────────────────
 
 describe('Dropdown — displayName', () => {

--- a/src/Dropdown/Dropdown.tsx
+++ b/src/Dropdown/Dropdown.tsx
@@ -136,6 +136,14 @@ export interface DropdownProps<T extends string | number = string> {
    *  trigger and menu are suppressed. */
   onBlur?: (event: React.FocusEvent) => void;
 
+  /** Allow option description text to wrap instead of truncating.
+   *  When false (default), descriptions are single-line with ellipsis. */
+  wrapDescriptions?: boolean;
+
+  /** Show the selected option's description in the trigger alongside
+   *  the label. Only applies in "select" mode with the default trigger. */
+  showDescriptionInTrigger?: boolean;
+
   /** Children — used for compound component pattern (Dropdown.Item, etc.) */
   children?: ReactNode;
 }
@@ -325,6 +333,8 @@ function DropdownInner<T extends string | number = string>(
     renderOption,
     renderTag,
     renderEmpty,
+    wrapDescriptions = false,
+    showDescriptionInTrigger = false,
     maxMenuHeight = 300,
     className = '',
     style,
@@ -783,7 +793,14 @@ function DropdownInner<T extends string | number = string>(
               {renderIcon(selectedOpt.icon)}
             </span>
           )}
-          <span className="oc-dropdown__value">{selectedOpt.label}</span>
+          {showDescriptionInTrigger && selectedOpt.description ? (
+            <div className="oc-dropdown__trigger-value-group">
+              <span className="oc-dropdown__value">{selectedOpt.label}</span>
+              <span className="oc-dropdown__trigger-description">{selectedOpt.description}</span>
+            </div>
+          ) : (
+            <span className="oc-dropdown__value">{selectedOpt.label}</span>
+          )}
         </div>
       );
     }
@@ -1089,6 +1106,7 @@ function DropdownInner<T extends string | number = string>(
     fluid && 'oc-dropdown--fluid',
     isOpen && 'oc-dropdown--open',
     disabled && 'oc-dropdown--disabled',
+    wrapDescriptions && 'oc-dropdown--wrap-descriptions',
     className,
   ].filter(Boolean).join(' ');
 


### PR DESCRIPTION
Fixes #10: Description text was hard-truncated with white-space: nowrap
and selected options only showed the label in the trigger.

- wrapDescriptions (bool, default false): adds oc-dropdown--wrap-descriptions
  class that allows option descriptions to wrap naturally instead of truncating
- showDescriptionInTrigger (bool, default false): renders the selected
  option's description below its label in the default trigger
- Added CSS for .oc-dropdown__trigger-value-group and
  .oc-dropdown__trigger-description
- Added tests covering both new props
- Added WrappedDescriptions and DescriptionInTrigger stories