### PR TITLE
fix: frozen header cell z-index with stickyHeader

### DIFF
--- a/src/Table/Table.styles.ts
+++ b/src/Table/Table.styles.ts
@@ -162,6 +162,17 @@ export const tableStyles = `
   background-color: #f8fafc;
 }
 
+/* Frozen column + sticky header: needs z-index above other sticky-header
+   cells (z-index 10) so scrolling headers don't paint over the frozen one.
+   Specificity must beat .oc-table--sticky-header .oc-table__head-cell. */
+.oc-table--sticky-header .oc-table__head-cell--sticky-left {
+  z-index: 12;
+}
+
+.oc-table--sticky-header .oc-table__head-cell--sticky-right {
+  z-index: 12;
+}
+
 .oc-table__head-cell--sticky-left::after,
 .oc-table__cell--sticky-left::after {
   content: '';


### PR DESCRIPTION
## Summary
- The `.oc-table--sticky-header .oc-table__head-cell` rule (specificity 0,2,0) was overriding `z-index: 11` from `.oc-table__head-cell--sticky-left` (specificity 0,1,0), setting the frozen header cell to z-index 10 — same as other headers
- Added higher-specificity combined rules (`.oc-table--sticky-header .oc-table__head-cell--sticky-left/right`) with `z-index: 12` so the frozen header cell paints above scrolling headers

## Test plan
- [x] All 67 Table tests pass