### PR TITLE
fix: keep SearchBox icon and input on one row at ≤480px

### DIFF
--- a/src/SearchBox/SearchBox.styles.ts
+++ b/src/SearchBox/SearchBox.styles.ts
@@ -125,17 +125,19 @@ export const searchBoxStyles = `
     flex-wrap: wrap;
   }
 
-  .oc-search-box__input {
-    flex: 1 1 100%;
-    order: 1;
-  }
-
   .oc-search-box__icon {
     order: 0;
   }
 
+  .oc-search-box__input {
+    order: 1;
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
   .oc-search-box__button {
     order: 2;
+    flex: 1 1 100%;
     width: 100%;
     margin-top: 8px;
   }


### PR DESCRIPTION
## Summary
- Fixes #27 — at viewport widths ≤480px the `SearchBox` icon detached onto its own row, leaving the magnifying-glass icon floating above the input.
- Root cause: the `@media (max-width: 480px)` block gave `.oc-search-box__input` `flex: 1 1 100%`, forcing it onto its own flex line. With `flex-wrap: wrap`, the `order: 0` icon was pushed onto the line above it.
- Fix: the input now uses `flex: 1 1 auto` so it shares the first row with the icon; only the button keeps `flex: 1 1 100%` and wraps to a full-width second row.

## Test plan
- [ ] Render `<SearchBox placeholder="Search…" />` at ≤480px (e.g. 390px) and confirm `[icon + input]` on one row, `[button]` full-width below.
- [ ] Confirm desktop (>480px) layout is unchanged.
- [ ] `npm run build` passes.