### PR TITLE
fix(SearchBox): keep icon and input on one row at ≤480px

### DIFF
--- a/src/SearchBox/SearchBox.stories.tsx
+++ b/src/SearchBox/SearchBox.stories.tsx
@@ -122,3 +122,23 @@ export const CustomButtonContent: Story = {
     ),
   ],
 };
+
+/**
+ * At ≤480px the icon and input stay together on the first row and only the
+ * button wraps to a full-width second row. Regression coverage for the mobile
+ * layout reported in issues #27 and #33, where the leading search icon was
+ * stranded on its own line above the input.
+ */
+export const MobileLayout: Story = {
+  args: {
+    placeholder: 'Search across all legal knowledge, cases, and statutes...',
+    buttonText: 'Search',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 320 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/src/SearchBox/SearchBox.styles.ts
+++ b/src/SearchBox/SearchBox.styles.ts
@@ -131,7 +131,12 @@ export const searchBoxStyles = `
 
   .oc-search-box__input {
     order: 1;
-    flex: 1 1 auto;
+    /* Zero flex-basis (matching the desktop base rule) keeps the input on the
+       first row beside the icon regardless of its intrinsic width, so the
+       leading icon is never stranded on a row of its own. A non-zero basis
+       (e.g. auto or 100%) lets the input's hypothetical size push it onto a
+       new flex line on narrow viewports. */
+    flex: 1 1 0;
     min-width: 0;
   }
 

--- a/src/SearchBox/SearchBox.test.tsx
+++ b/src/SearchBox/SearchBox.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { SearchBox } from './SearchBox';
+import { searchBoxStyles } from './SearchBox.styles';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('SearchBox', () => {
+  it('renders the icon, input and button in document order', () => {
+    const { container } = render(<SearchBox placeholder="Search..." />);
+
+    const form = container.querySelector('.oc-search-box') as HTMLElement;
+    const children = Array.from(form.children);
+
+    expect(children[0].classList.contains('oc-search-box__icon')).toBe(true);
+    expect(children[1].classList.contains('oc-search-box__input')).toBe(true);
+    expect(children[2].classList.contains('oc-search-box__button')).toBe(true);
+  });
+
+  it('omits the button when hideButton is set', () => {
+    const { container } = render(<SearchBox hideButton />);
+    expect(container.querySelector('.oc-search-box__button')).toBeNull();
+  });
+
+  // ─── Mobile layout regression (issues #27, #33) ───────────────────────────
+  // On screens ≤ 480px the leading search icon must stay on the first row
+  // beside the input, with only the button wrapping to a full-width second
+  // row. A non-zero flex-basis on the input (e.g. `1 1 100%` or `1 1 auto`)
+  // lets the input's hypothetical size push it onto its own flex line and
+  // strands the icon above it. jsdom can't perform flex layout, so we assert
+  // on the CSS rule that governs the wrap.
+  describe('mobile layout (≤480px)', () => {
+    const mobileBlock = (() => {
+      const match = searchBoxStyles.match(
+        /@media\s*\(max-width:\s*480px\)\s*\{([\s\S]*)\}\s*$/
+      );
+      expect(match, 'expected a max-width: 480px media query').not.toBeNull();
+      return match![1];
+    })();
+
+    const ruleFor = (selector: string) => {
+      const re = new RegExp(
+        `${selector.replace(/[.]/g, '\\.')}\\s*\\{([^}]*)\\}`
+      );
+      const m = mobileBlock.match(re);
+      expect(m, `expected a rule for ${selector}`).not.toBeNull();
+      return m![1];
+    };
+
+    it('lets the input share the first row with the icon (zero flex-basis)', () => {
+      const inputRule = ruleFor('.oc-search-box__input');
+      const flex = inputRule.match(/flex:\s*([^;]+);/)?.[1].trim();
+
+      // Must grow/shrink with a zero basis so it never forces its own line.
+      expect(flex).toBe('1 1 0');
+      // Guard against the regressions reported in #27 / #33.
+      expect(flex).not.toContain('100%');
+      expect(flex).not.toContain('auto');
+      expect(inputRule).toMatch(/min-width:\s*0/);
+    });
+
+    it('wraps the button onto a full-width second row', () => {
+      const buttonRule = ruleFor('.oc-search-box__button');
+      expect(buttonRule).toMatch(/width:\s*100%/);
+      expect(buttonRule).toMatch(/order:\s*2/);
+    });
+
+    it('orders the icon before the input', () => {
+      expect(ruleFor('.oc-search-box__icon')).toMatch(/order:\s*0/);
+      expect(ruleFor('.oc-search-box__input')).toMatch(/order:\s*1/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #33 — on screens ≤ 480px the leading search icon was stranded on its own line above the input (icon / input / button rendering as three stacked rows).

## Root cause

The `@media (max-width: 480px)` rule gave `.oc-search-box__input` a **non-zero flex-basis**. With `flex-wrap: wrap`, an item's *hypothetical* (flex-basis) size — not its shrunk size — is what the line-collection algorithm uses to decide wrapping. A non-zero basis lets the input's hypothetical size exceed the remaining space next to the icon, so the input wraps onto its own flex line and leaves the `flex-shrink: 0` icon alone on the row above.

Note: the specific value reported in #33 (`flex: 1 1 100%`) was already changed to `flex: 1 1 auto` in 0.1.20 (the #27 fix, which the reporter hadn't tested — they were on 0.1.19). But `auto` is still not bulletproof: it relies on the input's intrinsic width fitting beside the icon, so on a sufficiently narrow viewport the icon can still be stranded. That's why this bug has now been filed twice.

## Fix

Set the input to `flex: 1 1 0` in the ≤480px media query — a **zero flex-basis**, matching the desktop base rule (`flex: 1`). The input's hypothetical size is then 0, so it always shares the first row with the icon and grows to fill the remaining space; only the full-width button wraps to a second row. This holds regardless of the input's intrinsic width or the viewport width.

## Regression coverage

- **`SearchBox.test.tsx`** (new) — asserts DOM order (icon → input → button) and pins the mobile flex rule: input must be `flex: 1 1 0` with `min-width: 0` (and explicitly *not* `100%`/`auto`), button full-width, icon ordered before input. jsdom can't perform flex layout, so the guard is on the CSS-in-JS rule that governs the wrap.
- **`MobileLayout` story** at 320px with a long placeholder — visual regression coverage for the reported scenario.

## Verification

- `npm run test` — 156 passed (5 new)
- `npm run lint` — clean
- `npm run build` — success

https://claude.ai/code/session_01VMc2dtCs97wcswd8uwMddo

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMc2dtCs97wcswd8uwMddo)_